### PR TITLE
Added --verbose flag and credentials for deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,6 @@ env:
   PERCY_PARALLEL_TOTAL: 9
 
 jobs:
-  check-properties:
-    name: Check properties (temporary)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Log github.ref
-        run: echo ${{ github.ref }}
-
-      - name: Log github.head_ref
-        run: echo ${{ github.head_ref }}
-
-      - name: Log github.base_ref
-        run: echo ${{ github.base_ref }}
-
-
   build-ember-app:
     name: Build Ember app
     runs-on: ubuntu-latest
@@ -195,4 +180,6 @@ jobs:
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       - name: Deploy
-        run: yarn deploy
+        run: yarn deploy --verbose
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
## Description

This PR patches #2. When a push was made to the `main` branch, the [CI workflow](https://github.com/ijlee2/ijlee2.github.io/runs/1045748920?check_suite_focus=true) resulted the error message:

```bash
+- prepare
|  |
|  +- git
|    - preparing git in /home/runner/work/ijlee2.github.io/deploy-ijlee2.github.io
fatal: invalid reference: gh-pages
```

I found a few projects that used `ember-cli-deploy-git` and GitHub Actions to arrive at the conclusion that I should have passed the credentials that would allow making a change to the repo.


## References

- https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys
- https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key
- https://github.com/NullVoxPopuli/ember-jsqr/blob/master/.github/workflows/tests.yml#L71-L74
- https://github.com/alexlafroscia/ember-moveable/blob/main/.github/workflows/deploy.yml#L27-L30
- https://github.com/movableink/ember-bar-chart/blob/master/.github/workflows/deploy.yml#L29-L32
- https://github.com/josemarluedke/ember-focus-trap/blob/master/.github/workflows/ci.yml#L77-L80
- https://github.com/ember-intl/ember-intl/blob/master/.github/workflows/docs-master.yml#L19-L28